### PR TITLE
GM-231 유저 토큰 저장

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ ext {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.kafka:spring-kafka'
 
     implementation group: 'com.google.firebase', name: 'firebase-admin', version: '6.8.1'

--- a/src/main/java/com/gaaji/notification/adaptor/FcmSender.java
+++ b/src/main/java/com/gaaji/notification/adaptor/FcmSender.java
@@ -1,4 +1,4 @@
-package com.gaaji.notification.service;
+package com.gaaji.notification.adaptor;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
@@ -18,18 +18,19 @@ import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.env.Environment;
 import org.springframework.core.io.ClassPathResource;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
 @Slf4j
-@Service
-public class MessageService {
+@Component
+public class FcmSender {
 
 
     private final Environment env;
     private final String FCM_PRIVATE_KEY_PATH;
     private final String FIRE_BASE_SCOPE;
 
-    public MessageService(Environment env) {
+
+    public FcmSender(Environment env) {
         this.env = env;
         FCM_PRIVATE_KEY_PATH = env.getProperty("fcm.key.path");
         FIRE_BASE_SCOPE = env.getProperty("fcm.key.scope");
@@ -55,10 +56,17 @@ public class MessageService {
         }
     }
 
+
+    public void sendServerMessage(List<String> tokenList,  String body) {
+        sendByTokenList(tokenList,"가지마켓",body,
+                "https://todoay-picture.s3.ap-northeast-2.amazonaws.com/gaaji/fd308fa8-f9c1-4e2c-8a35-4c0816b51f23gajji.png");
+    }
+
     // 알림 보내기
-    public void sendByTokenList(List<String> tokenList,  String title, String body) {
+    private void sendByTokenList(List<String> tokenList,  String title, String body, String imgUrl) {
         // 메시지 만들기
         List<Message> messages = tokenList.stream().map(token -> Message.builder()
+                .putData("img", imgUrl)
                 .putData("time", LocalDateTime.now().toString())
                 .setNotification(new Notification(title, body))
                 .setToken(token)

--- a/src/main/java/com/gaaji/notification/config/RedisConfig.java
+++ b/src/main/java/com/gaaji/notification/config/RedisConfig.java
@@ -1,0 +1,43 @@
+package com.gaaji.notification.config;
+
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate() {
+        final StringRedisTemplate stringRedisTemplate = new StringRedisTemplate();
+        stringRedisTemplate.setKeySerializer(new StringRedisSerializer());
+        stringRedisTemplate.setValueSerializer(new StringRedisSerializer());
+        stringRedisTemplate.setConnectionFactory(redisConnectionFactory());
+        return stringRedisTemplate;
+    }
+
+}

--- a/src/main/java/com/gaaji/notification/controller/TempTokenSender.java
+++ b/src/main/java/com/gaaji/notification/controller/TempTokenSender.java
@@ -1,16 +1,11 @@
 package com.gaaji.notification.controller;
 
-import com.gaaji.notification.service.SendMessageService;
 import com.gaaji.notification.dto.ServerPushMessage;
-import com.gaaji.notification.dto.ServerPushMessageType;
-import java.util.List;
-import java.util.Map;
+import com.gaaji.notification.service.SendMessageService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor

--- a/src/main/java/com/gaaji/notification/controller/TempTokenSender.java
+++ b/src/main/java/com/gaaji/notification/controller/TempTokenSender.java
@@ -1,0 +1,28 @@
+package com.gaaji.notification.controller;
+
+import com.gaaji.notification.service.SendMessageService;
+import com.gaaji.notification.dto.ServerPushMessage;
+import com.gaaji.notification.dto.ServerPushMessageType;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class TempTokenSender {
+
+    private final SendMessageService service;
+
+    @PostMapping("/send")
+    public ResponseEntity<Void> send(@RequestBody ServerPushMessage body){
+        service.sendMessage(body);
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/src/main/java/com/gaaji/notification/controller/TokenSaveController.java
+++ b/src/main/java/com/gaaji/notification/controller/TokenSaveController.java
@@ -1,13 +1,16 @@
 package com.gaaji.notification.controller;
 
 
+import com.gaaji.notification.dto.FcmToken;
 import com.gaaji.notification.service.TokenSaveService;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -18,9 +21,8 @@ public class TokenSaveController {
 
 
     @PostMapping("/notification")
-    public ResponseEntity<Void> saveToken(@RequestBody Map<String,String> dto){
-        tokenSaveService.saveFcmToken(dto.get("userId"), dto.get("fcmToken"));
+    public ResponseEntity<Void> saveToken(@RequestHeader(HttpHeaders.AUTHORIZATION)String userId, @RequestBody FcmToken dto){
+        tokenSaveService.saveFcmToken(userId, dto.token());
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
-
 }

--- a/src/main/java/com/gaaji/notification/controller/TokenSaveController.java
+++ b/src/main/java/com/gaaji/notification/controller/TokenSaveController.java
@@ -1,0 +1,26 @@
+package com.gaaji.notification.controller;
+
+
+import com.gaaji.notification.service.TokenSaveService;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class TokenSaveController {
+
+    private final TokenSaveService tokenSaveService;
+
+
+    @PostMapping("/notification")
+    public ResponseEntity<Void> saveToken(@RequestBody Map<String,String> dto){
+        tokenSaveService.saveFcmToken(dto.get("userId"), dto.get("fcmToken"));
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+}

--- a/src/main/java/com/gaaji/notification/dto/FcmToken.java
+++ b/src/main/java/com/gaaji/notification/dto/FcmToken.java
@@ -1,0 +1,5 @@
+package com.gaaji.notification.dto;
+
+public record FcmToken(String token) {
+
+}

--- a/src/main/java/com/gaaji/notification/dto/ServerPushMessage.java
+++ b/src/main/java/com/gaaji/notification/dto/ServerPushMessage.java
@@ -1,0 +1,9 @@
+package com.gaaji.notification.dto;
+
+
+import java.util.List;
+
+
+public record ServerPushMessage(List<String> users, ServerPushMessageType type) {
+
+}

--- a/src/main/java/com/gaaji/notification/dto/ServerPushMessageType.java
+++ b/src/main/java/com/gaaji/notification/dto/ServerPushMessageType.java
@@ -1,0 +1,19 @@
+package com.gaaji.notification.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ServerPushMessageType {
+    INTEREST_CHANGED("관심 상품이 변경되었어요"),
+    NOTIFICATION("공지 사항을 확인해주세요"),
+    REPORT("당신은 고소당했습니다.")
+
+    ;
+
+
+    private final String body;
+
+
+}

--- a/src/main/java/com/gaaji/notification/repository/FakeTokenRepositoryImpl.java
+++ b/src/main/java/com/gaaji/notification/repository/FakeTokenRepositoryImpl.java
@@ -1,0 +1,28 @@
+package com.gaaji.notification.repository;
+
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.Assert;
+
+@Profile("redis-fake")
+@Transactional
+@Repository
+public class FakeTokenRepositoryImpl implements TokenRepository{
+
+    private static Map<String,String> storage = new ConcurrentHashMap<>();
+    @Override
+    public void write(String key, String value) {
+        storage.put(key,value);
+    }
+
+    @Override
+    public String read(String key) {
+        String value = storage.get(key);
+        Assert.notNull(value,"Key에 해당하는 값이 존재하지 않습니다.");
+        return value;
+    }
+}

--- a/src/main/java/com/gaaji/notification/repository/TokenRepository.java
+++ b/src/main/java/com/gaaji/notification/repository/TokenRepository.java
@@ -1,0 +1,9 @@
+package com.gaaji.notification.repository;
+
+
+
+public interface TokenRepository {
+
+    void write(String key, String value);
+    String read(String key);
+}

--- a/src/main/java/com/gaaji/notification/repository/TokenRepositoryImpl.java
+++ b/src/main/java/com/gaaji/notification/repository/TokenRepositoryImpl.java
@@ -1,0 +1,34 @@
+package com.gaaji.notification.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.Assert;
+
+@Profile({"redis-local","redis-docker"})
+@RequiredArgsConstructor
+@Transactional
+@Repository
+public class TokenRepositoryImpl implements TokenRepository{
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    @Override
+    public void write(String key, String value) {
+
+        ValueOperations<String, String> ops = stringRedisTemplate.opsForValue();
+        ops.set(key,value);
+
+    }
+
+    @Override
+    public String read(String key) {
+        ValueOperations<String, String> ops = stringRedisTemplate.opsForValue();
+        String value = ops.get(key);
+        Assert.notNull(value,"Key에 해당하는 값이 존재하지 않습니다.");
+        return value;
+    }
+}

--- a/src/main/java/com/gaaji/notification/service/SendMessageService.java
+++ b/src/main/java/com/gaaji/notification/service/SendMessageService.java
@@ -1,0 +1,27 @@
+package com.gaaji.notification.service;
+
+import com.gaaji.notification.adaptor.FcmSender;
+import com.gaaji.notification.dto.ServerPushMessage;
+import com.gaaji.notification.repository.TokenRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class SendMessageService {
+
+    private final TokenRepository tokenRepository;
+    private final FcmSender fcmSender;
+
+
+    public void sendMessage(ServerPushMessage dto){
+        List<String> tokens = dto.users().stream().map(u -> tokenRepository.read(u))
+                .collect(Collectors.toList());
+        fcmSender.sendServerMessage(tokens,dto.type().getBody());
+    }
+
+}

--- a/src/main/java/com/gaaji/notification/service/TokenSaveService.java
+++ b/src/main/java/com/gaaji/notification/service/TokenSaveService.java
@@ -1,0 +1,20 @@
+package com.gaaji.notification.service;
+
+
+import com.gaaji.notification.repository.TokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class TokenSaveService {
+    private final TokenRepository tokenRepository;
+
+    public void saveFcmToken(String userId, String fcmToken){
+        tokenRepository.write(userId, fcmToken);
+    }
+
+
+}

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -2,6 +2,7 @@ spring:
   config:
     activate:
       on-profile: "docker"
+
 eureka:
   client:
     fetch-registry: true

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -8,3 +8,13 @@ spring:
   config:
     activate:
       on-profile: local
+
+  redis:
+    host: localhost
+    password:
+    port: 6379
+    pool:
+      max-idle: 8
+      min-idle: 0
+      max-active: 8
+      max-wait: -1

--- a/src/main/resources/application-single.yml
+++ b/src/main/resources/application-single.yml
@@ -8,3 +8,12 @@ spring:
   config:
     activate:
       on-profile: single
+  redis:
+    host: localhost
+    password:
+    port: 6379
+    pool:
+      max-idle: 8
+      min-idle: 0
+      max-active: 8
+      max-wait: -1

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,5 +14,6 @@ spring:
     import:
       - noti.yml
       - kafka.yml
+      - redis.yml
   application:
     name: notification-service

--- a/src/main/resources/redis.yml
+++ b/src/main/resources/redis.yml
@@ -1,0 +1,28 @@
+spring:
+  config:
+    activate:
+      on-profile: "redis-docker"
+  redis:
+    host: redis
+    password:
+    port: 6379
+    pool:
+      max-idle: 8
+      min-idle: 0
+      max-active: 8
+      max-wait: -1
+
+---
+spring:
+  config:
+    activate:
+      on-profile: "redis-local"
+  redis:
+    host: localhost
+    password:
+    port: 6379
+    pool:
+      max-idle: 8
+      min-idle: 0
+      max-active: 8
+      max-wait: -1


### PR DESCRIPTION


# GM-231 유저 토큰 저장
## Description
> 유저 토큰을 저장한다. 

## PR Type
- [ ] Hotfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor (code, package, etc.)
- [ ] Build (gradle, spring, etc) 
- [ ] Documentation content changes (api docs, etc.)
- [ ] Infra (cloud, security, etc.)
- [ ] Other... Please describe :

## Issues

유저 토큰을 저장하는 API를 생성.
유저 토큰은 userId를 key, fcm_token을 value로 가지고 있다.
이후 push알람이 올 때는, 유저 ID를 보내서 해당 ID랑 맞는지 체크 후 value를 반환한다.
value로 받은 토큰 값을 활용해서 알람을 푸쉬함.

알람을 보내는 기능은 본래 Kafka의 이벤트로 작성하나, 현재 전송 형식이 정해지지 않아서 임시로 생성하였다.


![image](https://user-images.githubusercontent.com/76154390/218022009-67e9755f-1e06-447d-adde-9d688159fd3c.png)
![image](https://user-images.githubusercontent.com/76154390/218022032-e4867ecd-c2d4-4d3b-9858-31dc4a537ac9.png)

#### Bug
같은 방법을 사용했는데 MS EDGE에서는 토큰이 인증이 안되고 있음.

## Think About..  

어떤 메세지를 전송할 것인지를 정해야함.

## Conclusion  
> 일단은 테스트 프로필에선 Redis 대신 ConcurrentHashMap을 사용함
